### PR TITLE
Handle timer being cancelled while waiting

### DIFF
--- a/src/InfluxDB.Collector/Platform/PortableTimer.cs
+++ b/src/InfluxDB.Collector/Platform/PortableTimer.cs
@@ -37,7 +37,14 @@ namespace InfluxDB.Collector.Platform
 
             try
             {
-                await Task.Delay(interval, _cancel.Token);
+                if (!_cancel.Token.IsCancellationRequested)
+                {
+                    await Task.Delay(interval, _cancel.Token);
+                }
+            }
+            catch (TaskCanceledException) when (_cancel.IsCancellationRequested)
+            {
+                // currently disposing
             }
             finally
             {

--- a/test/InfluxDB.LineProtocol.Tests/Collector/MetricsCollectorTests.cs
+++ b/test/InfluxDB.LineProtocol.Tests/Collector/MetricsCollectorTests.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using InfluxDB.Collector;
 using InfluxDB.Collector.Pipeline;
 using Xunit;
+using System;
+using System.Threading.Tasks;
 
 namespace InfluxDB.LineProtocol.Tests.Collector
 {
@@ -37,6 +39,22 @@ namespace InfluxDB.LineProtocol.Tests.Collector
             Assert.Equal("42", point.Tags.Single().Value);
 
             Assert.NotNull(specialized);
+        }
+
+        [Fact]
+        public void CollectorCanBeDisposedWhileTimerIsWaiting()
+        {
+            var written = new TaskCompletionSource<object>();
+
+            var collector = new CollectorConfiguration()
+                .Batch.AtInterval(TimeSpan.FromDays(1))
+                .WriteTo.Emitter(_ => written.SetResult(null))
+                .CreateCollector();
+
+            collector.Increment("m");
+            written.Task.Wait();
+
+            collector.Dispose();
         }
     }
 }


### PR DESCRIPTION
Fixes #4 

TaskCanceledException was being thrown from Task.Delay if the timer was still waiting when it was disposed.