### PR TITLE
Dispose of underlying connections

### DIFF
--- a/sample/Benchmark/Benchmark.csproj
+++ b/sample/Benchmark/Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <AssemblyName>Sample</AssemblyName>
     <PackageId>Sample</PackageId>
     <ApplicationIcon />

--- a/sample/Sample-UDP-Support/Sample-UDP-Support.csproj
+++ b/sample/Sample-UDP-Support/Sample-UDP-Support.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Sample_UDP_Support</RootNamespace>
     <AssemblyName>Sample-UDP-Support</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <AssemblyName>Sample</AssemblyName>
     <PackageId>Sample</PackageId>
   </PropertyGroup>

--- a/src/InfluxDB.Collector/InfluxDB.Collector.csproj
+++ b/src/InfluxDB.Collector/InfluxDB.Collector.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>InfluxDB.Collector</AssemblyName>
-    <VersionPrefix>1.1.1</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <PackageId>InfluxDB.Collector</PackageId>
     <PackageTags>influxdb</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/influxdata/influxdb-csharp/master/asset/influxdata.jpg</PackageIconUrl>

--- a/src/InfluxDB.LineProtocol/Client/ILineProtocolClient.cs
+++ b/src/InfluxDB.LineProtocol/Client/ILineProtocolClient.cs
@@ -1,10 +1,11 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using InfluxDB.LineProtocol.Payload;
 
 namespace InfluxDB.LineProtocol.Client
 {
-    public interface ILineProtocolClient
+    public interface ILineProtocolClient : IDisposable
     {
         Task<LineProtocolWriteResult> SendAsync(
             LineProtocolWriter lineProtocolWriter,

--- a/src/InfluxDB.LineProtocol/Client/LineProtocolClient.cs
+++ b/src/InfluxDB.LineProtocol/Client/LineProtocolClient.cs
@@ -80,5 +80,10 @@ namespace InfluxDB.LineProtocol.Client
 
             return new LineProtocolWriteResult(false, $"{response.StatusCode} {response.ReasonPhrase} {body}");
         }
+
+        protected override void DisposeOfManagedResources()
+        {
+            _httpClient.Dispose();
+        }
     }
 }

--- a/src/InfluxDB.LineProtocol/Client/LineProtocolUdpClient.cs
+++ b/src/InfluxDB.LineProtocol/Client/LineProtocolUdpClient.cs
@@ -42,5 +42,10 @@ namespace InfluxDB.LineProtocol.Client
             int len = await _udpClient.SendAsync(buffer, buffer.Length, _udpHostName, _udpPort);
             return new LineProtocolWriteResult(len == buffer.Length, null);
         }
+
+        protected override void DisposeOfManagedResources()
+        {
+            _udpClient.Dispose();
+        }
     }
 }

--- a/src/InfluxDB.LineProtocol/InfluxDB.LineProtocol.csproj
+++ b/src/InfluxDB.LineProtocol/InfluxDB.LineProtocol.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>A .NET library for efficiently sending time series to InfluxDB</Description>
     <Authors>influxdb-csharp Contributors</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <VersionPrefix>1.1.1</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>InfluxDB.LineProtocol</AssemblyName>
     <PackageId>InfluxDB.LineProtocol</PackageId>

--- a/test/Consoles/InfluxDb.UdpSupport.ConsoleTest/App.config
+++ b/test/Consoles/InfluxDb.UdpSupport.ConsoleTest/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/test/Consoles/InfluxDb.UdpSupport.ConsoleTest/InfluxDb.UdpSupport.ConsoleTest.csproj
+++ b/test/Consoles/InfluxDb.UdpSupport.ConsoleTest/InfluxDb.UdpSupport.ConsoleTest.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>InfluxDb.UdpSupport.ConsoleTest</RootNamespace>
     <AssemblyName>InfluxDb.UdpSupport.ConsoleTest</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/test/InfluxDB.LineProtocol.Tests/InfluxDB.LineProtocol.Tests.csproj
+++ b/test/InfluxDB.LineProtocol.Tests/InfluxDB.LineProtocol.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <AssemblyName>InfluxDB.LineProtocol.Tests</AssemblyName>
     <PackageId>InfluxDB.LineProtocol.Tests</PackageId>
-    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This fixes #74 by making the base class disposable.