### PR TITLE
Configure CI to build on InfluxData account

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,8 @@
+Closes #
+
+_Briefly describe your proposed changes:_
+
+- [ ] CHANGELOG.md updated
+- [ ] Rebased/mergeable
+- [ ] Tests pass
+- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.2.0 [unreleased]
 
+### CI
+1. [#86](https://github.com/influxdata/influxdb-csharp/pull/86): AppVeyor deploy preview releases
+
 ## 1.1.1 [2020-04-14]
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# InfluxDB .NET Collector [![Build status](https://ci.appveyor.com/api/projects/status/0tqovixkf1e1pqu3/branch/master?svg=true)](https://ci.appveyor.com/project/NicholasBlumhardt/influxdb-lineprotocol/branch/master) [![NuGet Version](http://img.shields.io/nuget/v/InfluxDB.LineProtocol.svg?style=flat)](https://www.nuget.org/packages/InfluxDB.LineProtocol/)
+# InfluxDB .NET Collector
+
+[![Build status](https://img.shields.io/appveyor/build/influxdata/influxdb-csharp)](https://ci.appveyor.com/project/influxdata/influxdb-csharp/) 
+[![NuGet Version](http://img.shields.io/nuget/v/InfluxDB.LineProtocol.svg?style=flat)](https://www.nuget.org/packages/InfluxDB.LineProtocol/)
+[![License](https://img.shields.io/github/license/influxdata/influxdb-csharp.svg)](https://github.com/influxdata/influxdb-csharp/blob/master/LICENSE)
+[![GitHub issues](https://img.shields.io/github/issues-raw/influxdata/influxdb-csharp.svg)](https://github.com/influxdata/influxdb-csharp/issues)
+[![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/influxdata/influxdb-csharp.svg)](https://github.com/influxdata/influxdb-csharp/pulls)
+[![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://www.influxdata.com/slack)
 
 ### Note: This library is for use with InfluxDB 1.x. For connecting to InfluxDB 2.x instances, please use the [influxdb-client-csharp](https://github.com/influxdata/influxdb-client-csharp) client.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,4 +13,4 @@ deploy:
     secure: /Dm+EI0E1vCa+rZfYkluSnk7iSnAFKNOcEpreQrG88uYqCm//dKpY5vwqb1EJm3j
   skip_symbols: true
   on:
-    branch: /^(master|dev)$/
+    branch: dev

--- a/src/InfluxDB.Collector/Util/PseudoHighResTimestampSource.cs
+++ b/src/InfluxDB.Collector/Util/PseudoHighResTimestampSource.cs
@@ -25,17 +25,17 @@ namespace InfluxDB.Collector.Util
   
         public DateTime GetUtcNow()
         {
-            DateTime utcNow = DateTime.UtcNow;
-
             lock (lockObj)
             {
-                if (utcNow.Ticks == _lastUtcNowTicks)
+                DateTime utcNow = DateTime.UtcNow;
+                
+                if (utcNow.Ticks <= _lastUtcNowTicks)
                 {
                     // UtcNow hasn't rolled over yet, so 
                     // add a sequence number to it
                     _sequence++;
-                    long pseudoTicks = utcNow.Ticks + _sequence;
-                    return new DateTime(pseudoTicks, DateTimeKind.Utc);
+                    _lastUtcNowTicks = utcNow.Ticks + _sequence;
+                    return new DateTime(_lastUtcNowTicks, DateTimeKind.Utc);
                 }
                 else
                 {


### PR DESCRIPTION
Part of #63

1. fixed PseudoHighResTimestampSource to work in parallel environment 
2. Added link to InfluxData's AppVeyor build + other social icons
3. Added template for Pull-Requests
4. Configure AppVeyor only to deploy nightly builds from 'dev' branch

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

@nblumhardt could you review this - https://github.com/influxdata/influxdb-csharp/commit/c85f2946b0c944cfd8e72e13459241b3da8dd56f?

@russorat could you please enable `influxdata/influxdb-csharp` to build in AppVeyor and my account to configure this build?

![Screenshot 2020-04-14 at 09 52 36](https://user-images.githubusercontent.com/455137/79209047-324c6f00-7e43-11ea-8682-befdaf64173a.png)