### PR TITLE
Fix LineProtocolSyntax backslash escaping

### DIFF
--- a/src/InfluxDB.LineProtocol/Payload/LineProtocolSyntax.cs
+++ b/src/InfluxDB.LineProtocol/Payload/LineProtocolSyntax.cs
@@ -65,7 +65,7 @@ namespace InfluxDB.LineProtocol.Payload
 
         static string FormatString(string s)
         {
-            return "\"" + s.Replace("\"", "\\\"") + "\"";
+            return "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
         }
 
         public static string FormatTimestamp(DateTime utcTimestamp)

--- a/test/InfluxDB.LineProtocol.Tests/Payload/LineProtocolPayloadTests.cs
+++ b/test/InfluxDB.LineProtocol.Tests/Payload/LineProtocolPayloadTests.cs
@@ -6,7 +6,7 @@ using System.IO;
 
 namespace InfluxDB.LineProtocol.Tests
 {
-    public class LineProtcolPointTests
+    public class LineProtocolPointTests
     {
         [Fact]
         public void CompleteExampleFromDocs()
@@ -54,5 +54,31 @@ namespace InfluxDB.LineProtocol.Tests
 
             Assert.Equal(expected, sw.ToString());
         }
+
+        [Fact]
+        public void ExampleWithJsonTextWithNestedDoubleQuote()
+        {
+            const string expected = "\"measurement\\ with\\ json\\ with\\ quotes\",symbol=test field_key=\"{\\\"content\\\":\\\"test \\\\\\\" data\\\"}\" 1441756800000000000";
+
+            var json = "{\"content\":\"test \\\" data\"}";
+
+            var point = new LineProtocolPoint(
+                "\"measurement with json with quotes\"",
+                new Dictionary<string, object>
+                {
+                    { "field_key", json }
+                },
+                new Dictionary<string, string>
+                {
+                    { "symbol", "test" }
+                },
+                new DateTime(2015, 9, 9, 0, 0, 0, DateTimeKind.Utc));
+
+            var sw = new StringWriter();
+            point.Format(sw);
+
+            Assert.Equal(expected, sw.ToString());
+        }
+
     }
 }


### PR DESCRIPTION
- Fixes BadRequest response when writing a string field containing JSON with an escaped double quote.