### PR TITLE
chore: update System.Net.Http to 4.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 ### CI
 1. [#86](https://github.com/influxdata/influxdb-csharp/pull/86): AppVeyor deploy preview releases
 
+### Dependencies
+1. [#98](https://github.com/influxdata/influxdb-csharp/pull/98): Update dependencies:
+    - System.Net.Http to 4.3.4
+    
 ## 1.1.1 [2020-04-14]
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # InfluxDB .NET Collector
 
-[![Build status](https://img.shields.io/appveyor/build/influx/influxdb-csharp)](https://ci.appveyor.com/project/influx/influxdb-csharp/) 
+[![Build status](https://img.shields.io/appveyor/build/influx/influxdb-csharp/dev)](https://ci.appveyor.com/project/influx/influxdb-csharp/) 
 [![NuGet Version](http://img.shields.io/nuget/v/InfluxDB.LineProtocol.svg?style=flat)](https://www.nuget.org/packages/InfluxDB.LineProtocol/)
 [![License](https://img.shields.io/github/license/influxdata/influxdb-csharp.svg)](https://github.com/influxdata/influxdb-csharp/blob/master/LICENSE)
 [![GitHub issues](https://img.shields.io/github/issues-raw/influxdata/influxdb-csharp.svg)](https://github.com/influxdata/influxdb-csharp/issues)

--- a/src/InfluxDB.Collector/InfluxDB.Collector.csproj
+++ b/src/InfluxDB.Collector/InfluxDB.Collector.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="System.Threading" Version="4.3.0" />
     <PackageReference Include="System.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Console" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
   </ItemGroup>

--- a/src/InfluxDB.LineProtocol/InfluxDB.LineProtocol.csproj
+++ b/src/InfluxDB.LineProtocol/InfluxDB.LineProtocol.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="System.Threading" Version="4.3.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Globalization" Version="4.3.0" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
Closes #96
Closes #97 

Updated `System.Net.Http` to `4.3.4` - fix security vulnerability in System.Net.Http - https://github.com/advisories/GHSA-7jgj-8wvc-jh57

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)